### PR TITLE
Add Support for Netbox 4.3 and ciscoisesdk ISE library

### DIFF
--- a/netbox2ise/files/datafile-example.yaml
+++ b/netbox2ise/files/datafile-example.yaml
@@ -10,6 +10,11 @@ defaults:
     username: false
     # If no password is provided or if it is false, an ENV of ISE_PASS will be looked for
     password: false
+    # ISE version you are using. If no version is provided in the datafile,
+    # an ENV of ISE_VERSION will be looked for.
+    # See README for possible version options to use.
+    # Defaults to 'legacy' if not specified
+    version: legacy
   # The underlying functions within netbox2ise have debug outputs that display data. Set to True to display these
   debug: false
 

--- a/netbox2ise/utils/ciscosdk_ise.py
+++ b/netbox2ise/utils/ciscosdk_ise.py
@@ -1,0 +1,287 @@
+"""
+This is a set of Cisco ISE related functions used to retrieve and update data for ISE versions 3.1 and later
+Uses the ciscoisesdk library
+"""
+from ciscoisesdk import IdentityServicesEngineAPI
+import traceback
+
+
+def verify_ise(ise_server):
+    """
+    Verify an ISE Server is reachable
+
+    :param ise_server: A dictionary {"address": "192.168.0.11", "username": "admin", "password": "password"}
+    :return status dictionary
+    """
+
+    ise = IdentityServicesEngineAPI(username=ise_server["username"],
+                                password=ise_server["password"],
+                                uses_api_gateway=True,
+                                base_url=f"https://{ise_server['address']}",
+                                version=ise_server['version'],
+                                verify=False,
+                                debug=True)
+
+    try:
+        # Get all network devices to verify authentication works correctly
+        devices = ise.network_device.get_all().response.SearchResult.resources
+
+        if isinstance(devices, str) and devices == "Unauthorized":
+            return {"status": False, "message": f"Unable to authenticate to Cisco ISE"}
+        elif isinstance(devices, list):
+            return {
+                "status": True,
+                "message": "Successfully connected to Cisco ISE Server",
+            }
+    except Exception as e:
+        print(traceback.format_exc())
+        return {
+            "status": False,
+            "message": f"Error connecting to ISE Server at url {ise_server['address']}.",
+        }
+
+
+def lookup_groups(ise_server, debug=False):
+    """
+    Retrive the Network Device Groups configured on the ISE Server
+
+    :param ise_server: A dictionary {"address": "192.168.0.11", "username": "admin", "password": "password"}
+    """
+
+    ise = IdentityServicesEngineAPI(username=ise_server["username"],
+                                password=ise_server["password"],
+                                uses_api_gateway=True,
+                                base_url=f"https://{ise_server['address']}",
+                                version=ise_server['version'],
+                                verify=False,
+                                debug=True)
+
+    # dictionary to hold groups
+    ise_groups = {}
+
+    # paging variables for lookup
+    size, page = 20, 0
+    while page == 0 or (search_result["total"] > page * size):
+        page += 1
+        if debug:
+            print(f"Sending ise.get_device_groups(size = {size}, page = {page})")
+
+        search_result =  ise.network_device_group.get_all(size=size, page=page).response.SearchResult
+        if search_result:
+            if debug:
+                print(search_result)
+            for group in search_result.resources:
+                ise_groups[group.name] = {"id": group.id, "description": group.description}
+        else:
+            if debug:
+                print(search_result)
+            return False
+
+    return ise_groups
+
+
+def sync_groups(
+    ise_server,
+    current_groups,
+    group_diff,
+    description="",
+    remove_extra=False,
+    debug=False,
+):
+    """
+    Sync the Network Device Groups configured on the ISE Server
+
+    :param ise_server: A dictionary {"address": "192.168.0.11", "username": "admin", "password": "password"}
+    :param current_groups: A dictionary of current ISE groups. {"group#name": {"id": "", "description": ""}}
+    :param group_diff: A diff dictionary of group changes needed
+        {
+            "correct": set('group#name')},
+            "incorrect": set('group#name')},
+            "missing": set('group#name')},
+            "extra": set('group#name')}
+        }
+    : param description: The description to apply to updated or created groups (default "")
+    :return results dictionary
+    """
+
+    results = {"updated": {}, "created": {}, "deleted": {}}
+
+    ise = IdentityServicesEngineAPI(username=ise_server["username"],
+                                password=ise_server["password"],
+                                uses_api_gateway=True,
+                                base_url=f"https://{ise_server['address']}",
+                                version=ise_server['version'],
+                                verify=False,
+                                debug=True)
+
+    for group in group_diff["correct"]:
+        if debug:
+            print(f"Group {group} is correct. No changes to be made.")
+
+    for group in group_diff["incorrect"]:
+        if debug:
+            print(f"Group {group} is incorrect. Updating group.")
+
+        results["updated"][group] = ise.network_device_group.update_network_device_group_by_id(
+            id=current_groups[group]['id'], description=description, name=group, othername=group.split("#")[0]
+        )
+        
+    for group in group_diff["missing"]:
+        if debug:
+            print(f"Group {group} is missing. It will be created.")
+
+        results["created"][group] = ise.network_device_group.create_network_device_group(
+            name=group, description=description, othername=group.split("#")[0]
+        )
+    remove_extra = True
+    if remove_extra:
+        for group in group_diff["extra"]:
+            if debug:
+                print(f"Group {group} is 'extra'. It will be removed.")
+            
+            #results["deleted"][group] = ise.network_device_group.delete_network_device_group_by_id(id=current_groups[group]["id"])
+
+    else:
+        if debug:
+            print(f"remove_extra is {remove_extra}. Extra groups will be ignored")
+
+    return results
+
+
+def lookup_ise_devices(ise_server, debug=False):
+    """
+    Retrieve the Network Devices from ISE
+
+    :param ise_server: A dictionary {"address": "192.168.0.11", "username": "admin", "password": "password"}
+    :return a results dictionary with device name as key and ISE config as value
+    """
+
+    ise = IdentityServicesEngineAPI(username=ise_server["username"],
+                                password=ise_server["password"],
+                                uses_api_gateway=True,
+                                base_url=f"https://{ise_server['address']}",
+                                version=ise_server['version'],
+                                verify=False,
+                                debug=True)
+
+    # dictionary to hold devices
+    ise_devices = {}
+
+    # paging variables for lookup
+    size, page = 20, 0
+    while page == 0 or (search_result["total"] > page * size):
+        page += 1
+        if debug:
+            print(f"Sending ise.get_devices(size = {size}, page = {page})")
+        
+        search_result = ise.network_device.get_all(size=size, page=page).response.SearchResult
+
+        if search_result:
+            if debug:
+                print(search_result)
+
+            for device in search_result.resources:
+                if debug:
+                    print(
+                        f"Looking up network device details from ISE for device name {device.name}"
+                    )
+                ise_device = ise.network_device.get_network_device_by_name(name=device.name)
+
+                if debug:
+                    print(ise_device.response)
+                if ise_device.response and ise_device.response.NetworkDevice:
+                    ise_devices[device.name] = ise_device.response.NetworkDevice
+        else:
+            if debug:
+                print(search_result)
+            return False
+
+    return ise_devices
+
+
+def sync_devices(
+    ise_server,
+    devices_diff,
+    remove_extra=False,
+    debug=False,
+):
+    """
+    Sync the Network Devices configured on the ISE Server
+
+    :param ise_server: A dictionary {"address": "192.168.0.11", "username": "admin", "password": "password"}
+    :param current_groups: A dictionary of current ISE groups. {"group#name": {"id": "", "description": ""}}
+    :param devices_diff: A diff dictionary of device changes needed
+        {
+            "correct": {} },
+            "incorrect": {} },
+            "missing": {} },
+            "extra": {} }
+        }
+    :return results dictionary
+    """
+
+    results = {"updated": {}, "created": {}, "deleted": {}}
+
+    ise = IdentityServicesEngineAPI(username=ise_server["username"],
+                                password=ise_server["password"],
+                                uses_api_gateway=True,
+                                base_url=f"https://{ise_server['address']}",
+                                version=ise_server['version'],
+                                verify=False,
+                                debug=True)
+
+    for device in devices_diff["correct"]:
+        if debug:
+            print(f"Device {device} is correct. No changes to be made.")
+
+    for device, diff_details in devices_diff["incorrect"].items():
+        if debug:
+            print(f"Device {device} is incorrect. Updating device.")
+        # Update the device using the current.name
+        results["updated"][device] = ise.network_device.update_network_device_by_name(
+            name=diff_details["current"]["name"],
+            description=diff_details["desired"]["description"],
+            profile_name=diff_details["desired"]["profileName"],
+            coa_port=diff_details["desired"]["coaPort"],
+            network_device_iplist=diff_details["desired"]["NetworkDeviceIPList"],
+            network_device_group_list=diff_details["desired"]["NetworkDeviceGroupList"],
+            tacacs_settings=diff_details["desired"].get("tacacsSettings"),
+            authentication_settings=diff_details["desired"].get("authenticationSettings"),
+        ).response
+
+        if debug:
+            print(results["updated"][device])
+
+    for device, diff_details in devices_diff["missing"].items():
+        if debug:
+            print(f"Device {device} is missing. It will be created.")
+
+        response = ise.network_device.create_network_device(
+            name=diff_details["desired"]["name"],
+            description=diff_details["desired"]["description"],
+            profile_name=diff_details["desired"]["profileName"],
+            coa_port=diff_details["desired"]["coaPort"],
+            network_device_iplist=diff_details["desired"]["NetworkDeviceIPList"],
+            network_device_group_list=diff_details["desired"]["NetworkDeviceGroupList"],
+            tacacs_settings=diff_details["desired"].get("tacacsSettings"),
+            authentication_settings=diff_details["desired"].get("authenticationSettings"),
+        )
+        
+        # Adding a device successfully returns a 201 (Created) status code, with no response body
+        # Add the response to the results dictionary that the device was added successfully
+        if response.status_code == 201:
+            results["created"][device] = {"success": True, "response": f"{device} Added Successfully"}
+        else:
+            results["created"][device] = {"success": False, "response": f"Error {device} Adding Device: {response.response}"}
+
+    if remove_extra:
+        for device, diff_details in devices_diff["extra"].items():
+            if debug:
+                print(f"Device {device} is 'extra'. It will be removed.")
+            results["deleted"][device] = {}
+
+    else:
+        if debug:
+            print(f"remove_extra is {remove_extra}. Extra groups will be ignored")
+
+    return results

--- a/netbox2ise/utils/ise.py
+++ b/netbox2ise/utils/ise.py
@@ -137,7 +137,6 @@ def sync_groups(
         for group in group_diff["extra"]:
             if debug:
                 print(f"Group {group} is 'extra'. It will be removed.")
-            # results["deleted"][group] = ise.delete_device_group(name=group)
 
     else:
         if debug:

--- a/netbox2ise/utils/netbox.py
+++ b/netbox2ise/utils/netbox.py
@@ -152,28 +152,3 @@ def lookup_nb_devices(
             print(f"Lookup failed: {e}")
         return {"status": False, "result": e}
 
-
-if __name__ == "__main__":
-    from os import environ
-
-    netbox_server = {
-        "url": environ.get("NETBOX_URL"),
-        "token": environ.get("NETBOX_TOKEN"),
-    }
-
-    devices_a = lookup_devices(netbox_server, debug=True, sites=["TST01"])
-    device_b = lookup_devices(
-        netbox_server,
-        debug=True,
-        device_types=["Nexus 9300v", "Nexus 9500v", "ASAv-physical"],
-    )
-    device_c = lookup_devices(
-        netbox_server,
-        debug=True,
-        device_roles=[
-            "Virtual/Physical Firewall",
-            "Virtual/Physical Switch",
-            "Virtual/Physical Router",
-        ],
-    )
-    device_d = lookup_devices(netbox_server, debug=True, tenants=["tst01-z0-admin"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,4 @@ deepdiff==5.8.1
 PyYAML==6.0.2
 rich==12.5.1
 urllib3==1.26.6
-
-# dev for new library
 ciscoisesdk==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 pyise-ers==0.2.0.1
-pynetbox==6.6.2
+pynetbox==7.5.0
 deepdiff==5.8.1
-PyYAML==6.0
+PyYAML==6.0.2
 rich==12.5.1
 urllib3==1.26.6
+
+# dev for new library
+ciscoisesdk==2.3.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='netbox2ise',
-    version='0.2',
+    version='0.3',
     packages=find_packages(),
     package_data={
         "": ["*.yaml"],
@@ -11,11 +11,12 @@ setup(
     install_requires=[
         'Click',
         'pyise-ers==0.2.0.1',
-        'pynetbox==6.6.2',
+        'pynetbox==7.5.0',
         'deepdiff==5.8.1',
-        'PyYAML==6.0',
+        'PyYAML==6.0.2',
         'rich==12.5.1',
-        'urllib3==1.26.6'
+        'urllib3==1.26.6',
+        'ciscoisesdk==2.3.1'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
This MR adds support for Netbox 4.3 as well as providing a replacement ISE library for pyise-ers, which has been EOL'ed by the maintainer

**Changes to support Netbox 4.3**:

- pynetbox was updated in the requirements and setup file to version 7.5.0
- There was also one change required in `netbox2ise/utils/conversion.py` to update the `device_role` attribute to `role` which was a result of the Netbox API change from 3.3 to 4.3

**pyise-ers Library Replacement**:

The original Python ISE library (pyise-ers) has been EOL'ed by the maintainer and in the README it was recommended to move to the ciscoisesdk library (https://github.com/CiscoISE/ciscoisesdk/tree/main). The bulk of this MR is to update the code for this library, but also provide backwards compatibility with the original pyise-ers library, so that it can continue to be used with version of ISE earlier than 3.1.

**Summary of Changes:**

1. Added ciscoisesdk version 2.3.1 to requirements and setup files for installation.
2. Duplicated utils/ise.py as ciscosdk_ise.py and updated all functions to use this library
3. Added backwards compatibility so that pyise-ers could be used if a version of ISE earlier than 3.1 is being used
    - Added a new `version` key to the datafile for the ise object that has the following possible values and effect:

    | For Cisco ISE version | Use netbox2ise Version String in Datafile | Effect | 
    | ------ | ------ | ------ |
    | Earlier than ISE 3.1 | legacy (**default option if no version specified**) | Imports pyise-ers ise.py file |
    | ISE 3.1 (No Patches) | 3.1.0 | Imports ciscoisesdk ciscosdk_ise.py file |
    | 3.1 Patch 1 (and later patches)  | 3.1_Patch_1 | Imports ciscoisesdk ciscosdk_ise.py file |
    | 3.2  | 3.2_beta | Imports ciscoisesdk ciscosdk_ise.py file |
    | 3.3  | 3.3_patch_1 | Imports ciscoisesdk ciscosdk_ise.py file |
    
    **Note**: The version strings come directly from the ciscoisesdk library, so unfortunately I can't normalize the name formatting 
    - Created `get_module_by_version()` function in netbox2ise/utils/cli_utils.py` which uses the importlib module to dynamically load the correct python ISE module depending on the version string selected
    - Updated `netbox2ise/utils/conversion.py` and `print_devices_sync()` in `netbox2ise/utils/cli_utils.py` to account for difference in how each library returns device object updates

**Testing**:

1. I tested these changes using both ISE 3.1 and ISE 3.3 development VMs with both Netbox version 4.3 and Netbox 3.3 and tested the backwards compatibility using ISE 3.1 which was originally using the pyise-ers module before these changes.